### PR TITLE
Enable to override the cordova home folder

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -6,8 +6,10 @@ var fs = require('fs')
 var path = require('path')
 var cwd = process.cwd() //proj directory
 var scriptPath = __dirname //node_modules/cordova-uglify/scripts
+var pjson = require(path.join(cwd, '../../package.json'));
 
-var paths = [ path.join(cwd, '../../hooks'), path.join(cwd, '../../hooks/after_prepare') ];
+var cordovaHome = pjson.cordovaHome ? '../../' + pjson.cordovaHome : '../..';
+var paths = [ path.join(cwd, cordovaHome, 'hooks'), path.join(cwd, cordovaHome, 'hooks/after_prepare') ];
 
 for(var pathIndex in paths) {
   if(!fs.existsSync(paths[pathIndex])) {


### PR DESCRIPTION
In some projects it can be clearer to separate all Cordova stuffs in a separate folder. For instance, I like to have a simple project structure like that : 

```
package.json
|
\ src/
\ scripts/
\ cordova/
```

In this particular case the hooks folder is not accessible from `node_modules/../..` anymore. So I propose to add a `cordovaHome` prop in the `package.json` file to override the Cordova home path when needed.

I'm not sure this is the more elegant solution here but now you have the idea ;)
