### PR TITLE
JSON.stringify err in Error to make it readable in CLI

### DIFF
--- a/after_prepare/011_update_config.js
+++ b/after_prepare/011_update_config.js
@@ -292,7 +292,7 @@ var platformConfig = (function() {
       var xcodeProject = xcode.project(targetFile);
       xcodeProject.parse(function(err) {
         if (err) {
-          throw new Error('Failed to parse ' + targetFile + ': ' + err);
+          throw new Error('Failed to parse ' + targetFile + ': ' + JSON.stringify(err));
         }
         _.each(configItems, function(item) {
           if (item.data.attrib && item.data.attrib.name && item.data.attrib.value) {


### PR DESCRIPTION
I had these errors but only got [object Object] as `err`, adding `JSON.stringify` around it made the actual arror readable.
